### PR TITLE
fix: 비회원 주문에서 user_id가 null 인경우 에러 해결

### DIFF
--- a/src/main/java/shop/wannab/batchserver/batch/BatchConfig.java
+++ b/src/main/java/shop/wannab/batchserver/batch/BatchConfig.java
@@ -40,9 +40,12 @@ public class BatchConfig {
                         sum(o.totalDiscountAmount)
                     )
                     from Order o
-                    where o.orderAt >= :startDate
-                      and (o.orderStatus = shop.wannab.batchserver.order.OrderStatus.COMPLETED
-                           or o.orderStatus = shop.wannab.batchserver.order.OrderStatus.SHIPPING)
+                    where o.userId is not null
+                        and o.orderAt >= :startDate
+                        and o.orderStatus in (
+                            shop.wannab.batchserver.order.OrderStatus.COMPLETED,
+                            shop.wannab.batchserver.order.OrderStatus.SHIPPING
+                        )
                     group by o.userId
                     order by o.userId
                 """)

--- a/src/main/java/shop/wannab/batchserver/batch/processor/UpdateUserGradeProcessor.java
+++ b/src/main/java/shop/wannab/batchserver/batch/processor/UpdateUserGradeProcessor.java
@@ -55,7 +55,7 @@ public class UpdateUserGradeProcessor implements ItemProcessor<UserSpend, User> 
         }
     }
 
-    public Long determineNewGrade(int actualSpent) {
+    public Long determineNewGrade(long actualSpent) {
         if (actualSpent < 100000) {
             return standardUserGrade.getGradeId();
         } else if (actualSpent < 200000) {

--- a/src/main/java/shop/wannab/batchserver/order/Order.java
+++ b/src/main/java/shop/wannab/batchserver/order/Order.java
@@ -60,7 +60,6 @@ public class Order {
     @Column(name = "user_id")
     private Long userId;
 
-    @NotNull
     @Column(name = "recipient_name")
     private String recipientName;
 


### PR DESCRIPTION

-  <10/비회원 주문 조회 에러 해결> 

## 🥳 어떤 기능을 구현했나요?

>  등급 변경시 비회원 주문 조회하는 문제 해결

## 🔎 작업 상세 내용

- [x] 주문의 user_id가 null인 경우 조회하지 않도록 sql 수정
      
## ⏰ Pull Request 마감시간
> 

## 📚 참고할만한 자료(선택)

## 🔗 관련 이슈
Closes #10
